### PR TITLE
fix: update background color when dragging a schedule in monthly (fix: #3)

### DIFF
--- a/src/js/handler/month/moveGuide.js
+++ b/src/js/handler/month/moveGuide.js
@@ -33,11 +33,6 @@ function MonthMoveGuide(monthMove) {
      */
     this.layer = null;
 
-    /**
-     * @type {HTMLElement[]}
-     */
-    this.gridElements = null;
-
     monthMove.on({
         monthMoveDragstart: this._onDragStart,
         monthMoveDrag: this._onDrag,
@@ -60,8 +55,7 @@ MonthMoveGuide.prototype.destroy = function() {
         domutil.remove(this.element);
     }
 
-    this.monthMove = this.elements = this.layer =
-        this.gridElements = null;
+    this.monthMove = this.elements = this.layer = null;
 };
 
 /**
@@ -118,18 +112,17 @@ MonthMoveGuide.prototype._clearGridBgColor = function() {
  * @param {object} dragEvent - drag event data from MonthMoveGuide#_onDrag
  */
 MonthMoveGuide.prototype._updateGridBgColor = function(dragEvent) {
-    var gridElements = this.gridElements,
+    var gridElements = domutil.find(config.classname('.weekday-grid-line'), this.monthMove.monthView.container, true),
         className = config.classname('weekday-filled'),
-        targetIndex = (dragEvent.x + (dragEvent.sizeX * dragEvent.y)),
-        target = gridElements[targetIndex];
+        targetIndex = (dragEvent.x + (dragEvent.sizeX * dragEvent.y));
 
     this._clearGridBgColor();
 
-    if (!target) {
+    if (!gridElements || !gridElements[targetIndex]) {
         return;
     }
 
-    domutil.addClass(target, className);
+    domutil.addClass(gridElements[targetIndex], className);
 };
 
 /**
@@ -148,14 +141,6 @@ MonthMoveGuide.prototype._onDragStart = function(dragStartEvent) {
         layer = new FloatingLayer(null, container);
 
     this._hideOriginScheduleBlocks(model.cid());
-
-    if (!this.gridElements) {
-        this.gridElements = domutil.find(
-            config.classname('.weekday-grid-line'),
-            container,
-            true
-        );
-    }
 
     this.layer = layer;
     layer.setSize(widthPercent + '%', height);


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has description for the breaking change

### Description
The grid line element have `tui-full-calendar-weekday-filled` class to add background color.
`MonthMoveGuide` found the grid line element when `_onDragStart`,
but those elements was removed from DOM after re-rendering the calendar while dragging.
So now `MonthMoveGuide` finds the grid line element  `_onDrag`.



---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
