### PR TITLE
fix: resize the panel height error after dragging dvider (fix: #4)

### DIFF
--- a/src/js/common/vpanel.js
+++ b/src/js/common/vpanel.js
@@ -67,10 +67,11 @@ VPanel.prototype.isSplitter = function() {
 VPanel.prototype.setHeight = function(container, newHeight, force) {
     var maxHeight = this.options.maxHeight;
     var minHeight = this.options.minHeight;
+    var autoHeight = this.options.autoHeight;
     container = container || this.container;
 
     // 한번 force 호출이 일어난 이후에는 force 호출만 허용한다
-    if (!force && this.isHeightForcedSet) {
+    if (!force && this.isHeightForcedSet && !autoHeight) {
         return;
     }
 

--- a/test/app/common/vpanel.spec.js
+++ b/test/app/common/vpanel.spec.js
@@ -43,4 +43,13 @@ describe('VPanel', function() {
 
         expect(domutil.setData).toHaveBeenCalledWith(container, 'autoHeight', true);
     });
+
+    it('setHeight() can set specified height after force resizing if options.autoHeight is true', function() {
+        inst.options.autoHeight = true;
+        inst.isHeightForcedSet = true;
+
+        inst.setHeight(null, 350);
+
+        expect(container.style.height).toBe('350px');
+    });
 });


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has description for the breaking change

### Description
When the panel `options.autoHeight` is true, `setHeight()` properly set given height.
Dragging a divider to resize a panel set `isHeightForcedSet` flag. It had prevented to set height even in case of that `autoHeight` is true.


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
