### PR TITLE
fix: Wrong date parameter of beforeCreateSchedule callback near 24 o'click (fix #16)

### DIFF
--- a/src/js/handler/month/creation.js
+++ b/src/js/handler/month/creation.js
@@ -263,7 +263,7 @@ MonthCreation.prototype._onClick = function(e) {
         if (self._requestOnClick) {
             self.fire('monthCreationClick', eventData);
 
-            range = adjustStartAndEndTime(new TZDate(Number(eventData.date)), new TZDate(Number(eventData.date)));
+            range = self._adjustStartAndEndTime(new TZDate(Number(eventData.date)), new TZDate(Number(eventData.date)));
 
             self._createSchedule({
                 start: range.start,
@@ -277,20 +277,21 @@ MonthCreation.prototype._onClick = function(e) {
 };
 
 /**
- * Adjust time to half hour or hour o'clock
+ * Adjust time to our o'clock
  * @param {TZDate} start - start time
  * @param {TZDate} end - end time
  * @returns {Object} start and end
  */
-function adjustStartAndEndTime(start, end) {
+MonthCreation.prototype._adjustStartAndEndTime = function(start, end) {
     var now = new TZDate();
     var hours = now.getHours();
     var minutes = now.getMinutes();
+
+    // adjust start to less time. Adjusting had been greater time in monthly view when clicking grid
     if (minutes <= 30) {
-        minutes = 30;
-    } else {
-        hours += 1;
         minutes = 0;
+    } else {
+        minutes = 30;
     }
     start.setHours(hours, minutes, 0, 0);
     end.setHours(hours + 1, minutes, 0, 0);
@@ -299,7 +300,7 @@ function adjustStartAndEndTime(start, end) {
         start: start,
         end: end
     };
-}
+};
 
 /**
  * Returns whether the given element is Weekday-Schedule.

--- a/test/app/handler/month/creation.spec.js
+++ b/test/app/handler/month/creation.spec.js
@@ -1,0 +1,33 @@
+'use strict';
+
+var MonthCreation = require('handler/month/creation');
+var TZDate = require('common/timezone').Date;
+
+describe('MonthCreation', function() {
+    var proto;
+
+    beforeEach(function() {
+        proto = MonthCreation.prototype;
+    });
+
+    describe('_adjustStartAndEndTime()', function() {
+        it('provides exact clicking day when near 24 o\'clock', function() {
+            var result;
+
+            jasmine.clock().install();
+            jasmine.clock().mockDate(new Date('2018-03-07T23:37:00+09:00'));
+
+            result = proto._adjustStartAndEndTime(
+                new TZDate('2018-03-07T00:00:00+09:00'),
+                new TZDate('2018-03-07T00:00:00+09:00')
+            );
+
+            expect(result).toEqual({
+                start: new TZDate('2018-03-07T23:30:00+09:00'),
+                end: new TZDate('2018-03-08T00:30:00+09:00')
+            });
+
+            jasmine.clock().uninstall();
+        });
+    });
+});


### PR DESCRIPTION

<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has description for the breaking change

### Description
Select start time which does not over current time.


### Before
If the current time is `2018-03-08T23:38+09:00`, start time set to `2018-03-09T00:00+09:00` and end time set to `2018-03-09T01:00+09:00`.
So the day had been became next day.
(Time period is 1 hour.)

### After
To be exact the day which is clicked, change start time to do not over current time.
For example,
if the current time is `2018-03-08T23:38+09:00`, start time set to `2018-03-08T23:30+09:00` and end time set to `2018-03-09T00:30+09:00`.
(Time period is 1 hour.)



---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
