### PR TITLE
fix: stack the all-day and time schedule from the top (fix #29)

### DIFF
--- a/examples/js/data/schedules.js
+++ b/examples/js/data/schedules.js
@@ -79,7 +79,7 @@ function generateTime(schedule, renderStart, renderEnd) {
     }
 
     schedule.end = endDate
-        .add(chance.integer({min: 0, max: 4}), 'hour')
+        .add(chance.integer({min: 1, max: 4}), 'hour')
         .toDate();
 }
 

--- a/src/js/controller/viewMixin/month.js
+++ b/src/js/controller/viewMixin/month.js
@@ -174,7 +174,7 @@ var Month = {
      * @param {Date} start - start date to find schedules
      * @param {Date} end - end date to find schedules
      * @param {function[]} [andFilters] - optional filters to applying search query
-     * @param {boolean} [alldayFirstMode=true] if true, time schedule is lower than all-day schedule. Or stack schedules from the top.
+     * @param {boolean} [alldayFirstMode=false] if true, time schedule is lower than all-day schedule. Or stack schedules from the top.
      * @returns {object} view model data
      */
     findByDateRange: function(start, end, andFilters, alldayFirstMode) {

--- a/test/app/controller/viewMixin/month.spec.js
+++ b/test/app/controller/viewMixin/month.spec.js
@@ -49,8 +49,8 @@ describe('Base.Month', function() {
 * |15        |16        |17        |18        |19        |20        |21        |
 * |<<<<[김동우] 휴가>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>|
 * |          |<<<<김태용[오전반차]>>>>>>>>>>>>|          |          |          |
-* |          |<[류진경]>|<<<<[일본 출장] 김지해, 장세영>>>>>>>>>>>>>|          |
-* |          |<FE스크-1>|<[김성호]>|<FE스크-3>|<FE스크-4>|<FE스크-5>|          |
+* |          |<<[류진경]>>|<<<<[일본 출장] 김지해, 장세영>>>>>>>>>>>>>|          |
+* |          |<FE스크-1>|<<[김성호]>>|<FE스크-3>|<FE스크-4>|<FE스크-5>|          |
 * |          |          |<FE스크-2>|<[코드리]>|<팀스터디>|<주간보고>|          |
 * |          |          |<팀스터디>|          |<캘린더이>|          |          |
 */
@@ -74,6 +74,59 @@ describe('Base.Month', function() {
                 [undef, undef, 4],
                 [undef, undef, 5],
                 [undef, undef, 6]
+            ];
+
+            actual = controller.findByDateRange(start, end, null, true);
+
+            expect(actual[0]).toEqualMatricesTitle(expectedMatrix);
+            expect(actual[0]).toEqualMatricesTop(expectedTop);
+        });
+    });
+
+    describe('findByDateRange() by stacking time and all-day schedule', function() {
+        beforeEach(function() {
+            // add schedule instance to controller
+            util.forEach(scheduleList, function(schedule) {
+                base.addSchedule(schedule);
+            });
+
+            // test/matcher/matrices.js
+            jasmine.addMatchers(matricesMatcher());
+        });
+
+        it('get schedules instance in month', function() {
+            var start = new TZDate(2015, 10, 1),
+                end = new TZDate(2015, 10, 30);
+
+            /**
+* |15        |16        |17        |18        |19        |20        |21        |
+* |<<<<[김동우] 휴가>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>|
+* |          |<<<<김태용[일본출장]    >>>>>>>>>>>>| <FE스크-4>| <FE스크-5>|          |
+* |          |<<[류진경]>>|<<<<[일본 출장] 김지해, 장세영>>>>>>>>>>>>>>>>>>|          |
+* |          | <FE스크-1>|<<[김성호]>>| <FE스크-3>|  <팀스터디>|  <주간보고>|          |
+* |          |          |  <FE스크-2>| <[코드리]>|  <캘린더이>|          |          |
+* |          |          |   <팀스터디>|         |          |          |          |
+*/
+            var expectedMatrix = [
+                ['[김동우] 휴가', '김태용[일본출장]', '[류진경] 오전반차', '[김성호] 연차'],
+                [undef, 'FE 스크럼 - 4', '[일본 출장] 김지해, 장세영'],
+                [undef, '팀 스터디 - B', 'FE 스크럼 - 1'],
+                [undef, 'FE 스크럼 - 5', 'FE 스크럼 - 2'],
+                [undef, '주간보고 작성', '팀 스터디 - A'],
+                [undef, undef, 'FE 스크럼 - 3'],
+                [undef, undef, '[코드리뷰] 콤보차트 리펙토링'],
+                [undef, undef, '캘린더이야기']
+            ];
+
+            var expectedTop = [
+                [1, 2, 3, 4],
+                [undef, 2, 3],
+                [undef, 4, 4],
+                [undef, 2, 5],
+                [undef, 4, 6],
+                [undef, undef, 4],
+                [undef, undef, 5],
+                [undef, undef, 5]
             ];
 
             actual = controller.findByDateRange(start, end);


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has description for the breaking change

### Description
#### AS-IS
The time schedule had a top index bigger than all-day schedule. Any empty position was not used between all-day schedules.

#### TO-BE
The time schedule has a top index at empty position from the top.


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
