### PR TITLE
fix: all-day block width is wrong when resizing it (close #43)

### DIFF
--- a/src/js/handler/allday/core.js
+++ b/src/js/handler/allday/core.js
@@ -80,6 +80,10 @@ function getX(grids, left) {
     var i = 0;
     var length = grids.length;
     var grid;
+    if (left < 0) {
+        left = 0;
+    }
+
     for (; i < length; i += 1) {
         grid = grids[i];
         if (grid.left <= left && left <= (grid.left + grid.width)) {

--- a/src/js/handler/allday/resizeGuide.js
+++ b/src/js/handler/allday/resizeGuide.js
@@ -88,29 +88,24 @@ AlldayResizeGuide.prototype.refreshGuideElement = function(newWidth) {
 AlldayResizeGuide.prototype.getGuideElementWidthFunc = function(dragStartEventData) {
     var model = dragStartEventData.model,
         viewOptions = this.alldayResize.alldayView.options,
-        startDate = datetime.start(
-            new TZDate(Math.max(
-                model.start.getTime(),
-                datetime.parse(viewOptions.renderStartDate).getTime()
-            ))
-        ),
-        endDate = datetime.end(
-            new TZDate(Math.min(
-                model.end.getTime(),
-                datetime.parse(viewOptions.renderEndDate).getTime()
-            ))
-        ),
-        originLength = datetime.range(startDate, endDate, datetime.MILLISECONDS_PER_DAY).length,
-        baseWidthPercent = 100 / dragStartEventData.datesInRange,
-        dragStartIndex = dragStartEventData.xIndex;
+        fromLeft = (new TZDate(
+            model.start.getTime() - datetime.parse(viewOptions.renderStartDate)
+        )) / datetime.MILLISECONDS_PER_DAY | 0,
+        grids = dragStartEventData.grids;
 
     return function(xIndex) {
-        var offset = xIndex - dragStartIndex,
-            newLength = originLength + offset;
+        var width = 0;
+        var i = 0;
+        var length = grids.length;
+        width += grids[fromLeft] ? grids[fromLeft].width : 0;
 
-        newLength = Math.max(1, newLength);
+        for (; i < length; i += 1) {
+            if (i > fromLeft && i <= xIndex) {
+                width += grids[i] ? grids[i].width : 0;
+            }
+        }
 
-        return newLength * baseWidthPercent;
+        return width;
     };
 };
 

--- a/test/app/handler/allday/resizeGuide.spec.js
+++ b/test/app/handler/allday/resizeGuide.spec.js
@@ -31,7 +31,8 @@ describe('handler:AlldayResizeGuide', function() {
                 model: {
                     start: new Date('2015-05-04T00:00:00+09:00'),
                     end: new Date('2015-05-04T23:59:59+09:00')
-                }
+                },
+                grids: [{width: 20}, {width: 20}, {width: 20}, {width: 20}, {width: 20}]
             };
 
             var func = inst.getGuideElementWidthFunc.call(mockAlldayResize, mockDragStartEventData);


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [ ] It's submitted to right branch according to our branching model
- [ ] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description
In narrowWeekend options, grids information(left, width) should be used to calculate the width.


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
