### PR TITLE
creation failure of new all-day by clicking at right space(close #46)

### DIFF
--- a/src/js/common/domutil.js
+++ b/src/js/common/domutil.js
@@ -159,12 +159,13 @@ domutil = {
      * Find parent element recursively.
      * @param {HTMLElement} el - base element to start find.
      * @param {string} selector - selector string for find
+     * @param {boolean} excludeEl - exclude the base element to find
      * @returns {HTMLElement} - element finded or null.
      */
-    closest: function(el, selector) {
+    closest: function(el, selector, excludeEl) {
         var parent = el.parentNode;
 
-        if (domutil._matcher(el, selector)) {
+        if (!excludeEl && domutil._matcher(el, selector)) {
             return el;
         }
 

--- a/src/js/handler/allday/click.js
+++ b/src/js/handler/allday/click.js
@@ -67,7 +67,7 @@ AlldayClick.prototype._onClick = function(clickEvent) {
             clickEvent.target,
             config.classname('.allday-collapse-button')
         );
-    var blockElement, moreElement;
+    var blockElement, moreElement, scheduleElement;
 
     if (collapseElement) {
         self.fire('clickCollapse');
@@ -90,9 +90,10 @@ AlldayClick.prototype._onClick = function(clickEvent) {
         return;
     }
 
+    scheduleElement = domutil.closest(target, config.classname('.weekday-schedule'));
     blockElement = domutil.closest(target, config.classname('.weekday-schedule-block'));
-
-    if (blockElement) {
+    if (scheduleElement) {
+        blockElement = domutil.closest(target, config.classname('.weekday-schedule-block'));
         scheduleCollection.doWhenHas(domutil.getData(blockElement, 'id'), function(schedule) {
             /**
              * @events AlldayClick#clickSchedule

--- a/src/js/handler/allday/click.js
+++ b/src/js/handler/allday/click.js
@@ -91,7 +91,6 @@ AlldayClick.prototype._onClick = function(clickEvent) {
     }
 
     scheduleElement = domutil.closest(target, config.classname('.weekday-schedule'));
-    blockElement = domutil.closest(target, config.classname('.weekday-schedule-block'));
     if (scheduleElement) {
         blockElement = domutil.closest(target, config.classname('.weekday-schedule-block'));
         scheduleCollection.doWhenHas(domutil.getData(blockElement, 'id'), function(schedule) {

--- a/src/js/handler/allday/creation.js
+++ b/src/js/handler/allday/creation.js
@@ -87,17 +87,23 @@ AlldayCreation.prototype.checkExpectedCondition = function(target) {
     var alldayView = this.alldayView;
     var alldayViewType = alldayView.options.alldayViewType;
     var cssClass = domutil.getClass(target).trim();
-    var matches;
+    var excludeTarget = true;
+    var matches, schedulesElement;
 
     if (alldayViewType === 'toggle' && alldayView.collapsed) {
         return this._checkExpectedConditionOnToggleViewType(target);
     }
 
-    if (cssClass !== config.classname('weekday-schedules')) {
+    if (domutil.closest(target, config.classname('.weekday-schedule-block'), excludeTarget)) {
         return false;
     }
 
-    target = target.parentNode;
+    schedulesElement = domutil.closest(target, config.classname('.weekday-schedules'));
+    if (!schedulesElement && cssClass !== config.classname('weekday-schedules')) {
+        return false;
+    }
+
+    target = schedulesElement ? schedulesElement.parentNode : target.parentNode;
     cssClass = domutil.getClass(target);
     matches = cssClass.match(config.allday.getViewIDRegExp);
 
@@ -114,10 +120,12 @@ AlldayCreation.prototype.checkExpectedCondition = function(target) {
  * @returns {boolean} return WeekdayInWeek view instance when satiate condition.
  */
 AlldayCreation.prototype._checkExpectedConditionOnToggleViewType = function(target) {
+    var excludeTarget = true;
+
     return (domutil.closest(target, config.classname('.weekday-grid'))
         && !domutil.closest(target, config.classname('.weekday-exceed-in-week')))
         || (domutil.closest(target, config.classname('.weekday-schedules'))
-            && !domutil.closest(target, config.classname('.weekday-schedule-block')));
+            && !domutil.closest(target, config.classname('.weekday-schedule-block'), excludeTarget));
 };
 
 /**

--- a/src/js/handler/allday/move.js
+++ b/src/js/handler/allday/move.js
@@ -102,6 +102,7 @@ AlldayMove.prototype._onDragStart = function(dragStartEventData) {
     var target = dragStartEventData.target,
         result = this.checkExpectedCondition(target),
         controller = this.baseController,
+        excludeTarget = true,
         scheduleBlockElement,
         modelID,
         targetModel,
@@ -112,7 +113,7 @@ AlldayMove.prototype._onDragStart = function(dragStartEventData) {
         return;
     }
 
-    scheduleBlockElement = domutil.closest(target, config.classname('.weekday-schedule-block'));
+    scheduleBlockElement = domutil.closest(target, config.classname('.weekday-schedule-block'), excludeTarget);
     if (!scheduleBlockElement) {
         return;
     }

--- a/test/app/handler/allday/click.spec.js
+++ b/test/app/handler/allday/click.spec.js
@@ -28,7 +28,7 @@ describe('handler:AlldayClick', function() {
         // 클릭 대상 엘리먼트가 id '2'인 일정과 관계가 있을 때
         spyOn(domutil, 'getData').and.returnValue('2');
         spyOn(domutil, 'closest').and.callFake(function(target, cssClass) {
-            if (cssClass === config.classname('.weekday-schedule-block')) {
+            if (cssClass === config.classname('.weekday-schedule')) {
                 return true;
             }
 


### PR DESCRIPTION

<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has description for the breaking change

### Description
no firing event when click `tui-fullcalendar-weekday-schedule-block` element.
Because it has right padding and the real clickable element is `tui-fullcalendar-weekday-schedule` which is child of `block` element.


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
