### PR TITLE
fix: last daygrid vpanel must has showExpandableButton=false (close #85)

### DIFF
--- a/src/js/factory/weekView.js
+++ b/src/js/factory/weekView.js
@@ -85,26 +85,18 @@ var DEFAULT_PANELS = [
 
 /* eslint-disable complexity*/
 module.exports = function(baseController, layoutContainer, dragHandler, options) {
-    var panels = options.week.panels || DEFAULT_PANELS,
+    var panels = [],
         vpanels = [];
     var weekView, dayNameContainer, dayNameView, vLayoutContainer, vLayout;
-    var createView, onSaveNewSchedule, onSetCalendars;
+    var createView, onSaveNewSchedule, onSetCalendars, lastVPanel;
     var detailView, onShowDetailPopup, onDeleteSchedule, onShowEditPopup, onEditSchedule;
 
-    util.extend(options.week, {panels: panels});
-
-    weekView = new Week(null, options.week, layoutContainer, panels);
-    weekView.handler = {
-        click: {},
-        dayname: {},
-        creation: {},
-        move: {},
-        resize: {}
-    };
-
     // Make panels by view sequence and visibilities
-    util.forEach(panels, function(panel) {
+    util.forEach(DEFAULT_PANELS, function(panel) {
         var name = panel.name;
+
+        panel = util.extend({}, panel);
+        panels.push(panel);
 
         // Change visibilities
         if (name === 'milestone' || name === 'task') {
@@ -124,9 +116,32 @@ module.exports = function(baseController, layoutContainer, dragHandler, options)
     });
 
     if (vpanels.length) {
-        vpanels[vpanels.length - 1].autoHeight = true;
-        vpanels[vpanels.length - 1].maxHeight = null;
+        lastVPanel = vpanels[vpanels.length - 1];
+        lastVPanel.autoHeight = true;
+        lastVPanel.maxHeight = null;
+        lastVPanel.showExpandableButton = false;
+
+        util.forEach(panels, function(panel) {
+            if (panel.name === lastVPanel.name) {
+                panel.showExpandableButton = false;
+
+                return false;
+            }
+
+            return true;
+        });
     }
+
+    util.extend(options.week, {panels: panels});
+
+    weekView = new Week(null, options.week, layoutContainer, panels);
+    weekView.handler = {
+        click: {},
+        dayname: {},
+        creation: {},
+        move: {},
+        resize: {}
+    };
 
     dayNameContainer = domutil.appendHTMLElement('div', weekView.container, config.classname('dayname-layout'));
 


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has description for the breaking change

### Description
Copy panels array element  when using it.
And then `panel.showExpandableButton` set to false.
I change order of `new Week(...)` to after manipulating `panels`.

Check the scrollbar is visible and expandable button is hidden.
![image](https://user-images.githubusercontent.com/26706716/39414062-f3438798-4c6d-11e8-98d5-61cb78f98060.png)



---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
