### PR TITLE
fix: Update default details popup based on schedule item flags

### DIFF
--- a/src/js/view/template/popup/scheduleDetailPopup.hbs
+++ b/src/js/view/template/popup/scheduleDetailPopup.hbs
@@ -8,18 +8,21 @@
       <div class="{{CSS_PREFIX}}popup-detail-date {{CSS_PREFIX}}content">{{popupDetailDate-tmpl schedule.isAllDay schedule.start schedule.end}}</div>
     </div>
     <div class="{{CSS_PREFIX}}section-detail">
-        <div class="{{CSS_PREFIX}}popup-detail-item"><span class="{{CSS_PREFIX}}icon {{CSS_PREFIX}}ic-location-b"></span><span class="{{CSS_PREFIX}}content">{{popupDetailLocation-tmpl schedule}}</span></div>
-        <div class="{{CSS_PREFIX}}popup-detail-item"><span class="{{CSS_PREFIX}}icon {{CSS_PREFIX}}ic-user-b"></span><span class="{{CSS_PREFIX}}content">{{popupDetailUser-tmpl schedule}}</span></div>
+        {{#if schedule.location}}<div class="{{CSS_PREFIX}}popup-detail-item"><span class="{{CSS_PREFIX}}icon {{CSS_PREFIX}}ic-location-b"></span><span class="{{CSS_PREFIX}}content">{{popupDetailLocation-tmpl schedule}}</span></div>{{/if}}
+        {{#if schedule.attendees}}<div class="{{CSS_PREFIX}}popup-detail-item"><span class="{{CSS_PREFIX}}icon {{CSS_PREFIX}}ic-user-b"></span><span class="{{CSS_PREFIX}}content">{{popupDetailUser-tmpl schedule}}</span></div>{{/if}}
         <div class="{{CSS_PREFIX}}popup-detail-item"><span class="{{CSS_PREFIX}}icon {{CSS_PREFIX}}ic-state-b"></span><span class="{{CSS_PREFIX}}content">{{popupDetailState-tmpl schedule}}</span></div>
         {{#if calendar}}
         <div class="{{CSS_PREFIX}}popup-detail-item"><span class="{{CSS_PREFIX}}icon {{CSS_PREFIX}}calendar-dot" style="background-color: {{schedule.bgColor}}"></span><span class="{{CSS_PREFIX}}content">{{calendar.name}}</span></div>
         {{/if}}
     </div>
+    {{#if schedule.isReadOnly}}
+    {{else}}
     <div class="{{CSS_PREFIX}}section-button">
       <button class="{{CSS_PREFIX}}popup-edit"><span class="{{CSS_PREFIX}}icon {{CSS_PREFIX}}ic-edit"></span><span class="{{CSS_PREFIX}}content">{{popupEdit-tmpl}}</span></button>
       <div class="{{CSS_PREFIX}}popup-vertical-line"></div>
       <button class="{{CSS_PREFIX}}popup-delete"><span class="{{CSS_PREFIX}}icon {{CSS_PREFIX}}ic-delete"></span><span class="{{CSS_PREFIX}}content">{{popupDelete-tmpl}}</span></button>
     </div>
+    {{/if}}
   </div>
   <div class="{{CSS_PREFIX}}popup-top-line" style="background-color: {{schedule.bgColor}}"></div>
   <div id="{{CSS_PREFIX}}popup-arrow" class="{{CSS_PREFIX}}popup-arrow {{CSS_PREFIX}}arrow-left">


### PR DESCRIPTION
Fix: Modify the default schedule item details popup to respect the `isreadOnly` flag in the schedule item and not display the `edit` or `delete` actions.
Feat: Modify the default schedule item details popup to not display the `location` field if it is not set.
Feat: Modify the default schedule item details popup to not display the `atendees` field if it is not set.