### PR TITLE
fix: Schedules overlap when no duration (start == end) (close #154)

### DIFF
--- a/src/js/common/datetime.js
+++ b/src/js/common/datetime.js
@@ -107,6 +107,12 @@ datetime = {
     MILLISECONDS_PER_MINUTES: 60000,
 
     /**
+     * The number of milliseconds 20 minutes for schedule min duration
+     * @type {number}
+     */
+    MILLISECONDS_SCHEDULE_MIN_DURATION: 20 * 60000,
+
+    /**
      * convert milliseconds
      * @param {string} type - type of value.
      * @param {number} value - value to convert.

--- a/src/js/controller/viewMixin/week.js
+++ b/src/js/controller/viewMixin/week.js
@@ -11,6 +11,8 @@ var Collection = require('../../common/collection');
 var array = require('../../common/array');
 var datetime = require('../../common/datetime');
 
+var MILLISECONDS_SCHEDULE_MIN_DURATION = datetime.MILLISECONDS_SCHEDULE_MIN_DURATION;
+
 /**
  * @mixin Base.Week
  */
@@ -115,7 +117,13 @@ var Week = {
                     }
 
                     startTime = viewModel.getStarts().getTime();
-                    endTime = viewModel.getEnds().getTime() - 1;
+                    endTime = viewModel.getEnds().getTime();
+
+                    if (Math.abs(endTime - startTime) < MILLISECONDS_SCHEDULE_MIN_DURATION) {
+                        endTime += MILLISECONDS_SCHEDULE_MIN_DURATION;
+                    }
+
+                    endTime -= 1;
 
                     for (i = (col + 1); i < maxRowLength; i += 1) {
                         hasCollide = Week.hasCollide(binaryMap[i - 1], startTime, endTime);

--- a/src/js/model/viewModel/scheduleViewModel.js
+++ b/src/js/model/viewModel/scheduleViewModel.js
@@ -5,6 +5,9 @@
 'use strict';
 
 var util = require('tui-code-snippet');
+var datetime = require('../../common/datetime');
+
+var MILLISECONDS_SCHEDULE_MIN_DURATION = datetime.MILLISECONDS_SCHEDULE_MIN_DURATION;
 
 /**
  * Schedule ViewModel
@@ -178,6 +181,10 @@ ScheduleViewModel.prototype.collidesWith = function(viewModel) {
     if ((start > ownStarts && start < ownEnds) ||
         (end > ownStarts && end < ownEnds) ||
         (start <= ownStarts && end >= ownEnds)) {
+        return true;
+    }
+
+    if (Math.abs(start - ownStarts) < MILLISECONDS_SCHEDULE_MIN_DURATION) {
         return true;
     }
 


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [ ] It's submitted to right branch according to our branching model
- [ ] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description
Schedules which have no duration overlap, so I add a minimum duration to detect schedule collision. I choose 20 minutes because minimum height of schedule is about 19px when no duration. 30 minutes is about 24px. A minimun duration could be changed in the future.


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
