### PR TITLE
fix: save new location and new state during schedule update (issue 159)

### DIFF
--- a/examples/js/default.js
+++ b/examples/js/default.js
@@ -252,9 +252,9 @@
             bgColor: calendar.bgColor,
             dragBgColor: calendar.bgColor,
             borderColor: calendar.borderColor,
+            location: scheduleData.location,
             raw: {
-                'class': scheduleData.raw['class'],
-                location: scheduleData.raw.location
+                class: scheduleData.raw['class']
             },
             state: scheduleData.state
         };

--- a/src/js/controller/base.js
+++ b/src/js/controller/base.js
@@ -189,6 +189,14 @@ Base.prototype.updateSchedule = function(schedule, options) {
         schedule.set('isFocused', options.isFocused);
     }
 
+    if (options.location) {
+        schedule.set('location', options.location);
+    }
+
+    if (options.state) {
+        schedule.set('state', options.state);
+    }
+
     this._removeFromMatrix(schedule);
     this._addToMatrix(schedule);
 
@@ -363,7 +371,7 @@ Base.prototype.setTheme = function(theme) {
  * @property {string|number} id - calendar id
  * @property {string} name - calendar name
  * @property {string} color - text color when schedule is displayed
- * @property {string} bgColor - background color schedule is displayed 
+ * @property {string} bgColor - background color schedule is displayed
  * @property {string} borderColor - color of left border or bullet point when schedule is displayed
  * @property {boolean} [checked] - whether to show calendar's schedules or not
  */

--- a/src/js/view/popup/scheduleCreationPopup.js
+++ b/src/js/view/popup/scheduleCreationPopup.js
@@ -157,7 +157,7 @@ ScheduleCreationPopup.prototype._openDropdownMenuView = function(dropdown) {
 /**
  * If click dropdown menu item, close dropdown menu
  * @param {HTMLElement} target click event target
- * @returns {boolean} whether 
+ * @returns {boolean} whether
  */
 ScheduleCreationPopup.prototype._selectDropdownMenuItem = function(target) {
     var itemClassName = config.classname('dropdown-menu-item');
@@ -287,9 +287,9 @@ ScheduleCreationPopup.prototype._onClickSaveSchedule = function(target) {
             schedule: {
                 calendarId: calendarId,
                 title: title.value,
+                location: location.value,
                 raw: {
-                    class: isPrivate ? 'private' : 'public',
-                    location: location.value
+                    class: isPrivate ? 'private' : 'public'
                 },
                 start: start,
                 end: end,
@@ -312,9 +312,9 @@ ScheduleCreationPopup.prototype._onClickSaveSchedule = function(target) {
         this.fire('beforeCreateSchedule', {
             calendarId: calendarId,
             title: title.value,
+            location: location.value,
             raw: {
-                class: isPrivate ? 'private' : 'public',
-                location: location.value
+                class: isPrivate ? 'private' : 'public'
             },
             start: new TZDate(startDate),
             end: new TZDate(endDate),
@@ -378,7 +378,7 @@ ScheduleCreationPopup.prototype._makeEditModeData = function(viewModel) {
     var id = schedule.id;
     title = schedule.title;
     isPrivate = raw['class'] === 'private';
-    location = raw.location;
+    location = schedule.location;
     startDate = schedule.start;
     endDate = schedule.end;
     isAllDay = schedule.isAllDay;
@@ -402,8 +402,7 @@ ScheduleCreationPopup.prototype._makeEditModeData = function(viewModel) {
         start: startDate,
         end: endDate,
         raw: {
-            location: location,
-            'class': isPrivate ? 'private' : 'public'
+            class: isPrivate ? 'private' : 'public'
         },
         zIndex: this.layer.zIndex + 5,
         isEditMode: this._isEditMode


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [ ] It's submitted to right branch according to our branching model
- [ ] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description

The location and state are updatable in the scheduleCreationPopup but are actually not saved in the updateSchedule function. 

Fix for #159 : 
- Use schedule.location instead of schedule.raw.location in scheduleCreationPopup (as defined in the model) to be consistent with the detail popup
- Save sched.location and sched.state in updateSchedule function


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
