### PR TITLE
feat: disable statistics collection via options

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,13 @@
 ## Collect statistics on the use of open source
 
 TOAST UI Calendar applies Google Analytics (GA) to collect statistics on the use of open source, in order to identify how widely TOAST UI Calendar is used throughout the world. It also serves as important index to determine the future course of projects. location.hostname (e.g. > “ui.toast.com") is to be collected and the sole purpose is nothing but to measure statistics on the usage.
-To disable GA, include tui-code-snippet.js and then immediately write the options as follows:
+
+To disable GA use the [options](https://nhnent.github.io/tui.calendar/latest/global.html#Options):
 
 ```js
-tui.usageStatistics = false;
+var calendar = new Calendar('#calendar', {
+  usageStatistics: false
+});
 ```
 
 ## 🌏 Browser Support

--- a/src/index.js
+++ b/src/index.js
@@ -7,14 +7,9 @@
 
 var util = require('tui-code-snippet');
 var Calendar = require('./js/factory/calendar');
-var GA_TRACKING_ID = 'UA-129951699-1';
 
 require('./css/main.styl');
 require('./js/view/template/helper');
-
-if (util.sendHostname) {
-    util.sendHostname('calendar', GA_TRACKING_ID);
-}
 
 // for jquery
 if (global.jQuery) {

--- a/src/js/factory/calendar.js
+++ b/src/js/factory/calendar.js
@@ -4,6 +4,8 @@
  */
 'use strict';
 
+var GA_TRACKING_ID = 'UA-129951699-1';
+
 var util = require('tui-code-snippet'),
     Handlebars = require('handlebars-template-loader/runtime');
 var dw = require('../common/dw'),
@@ -422,6 +424,7 @@ var mmin = Math.min;
  * @property {boolean} [disableDblClick=false] - Disable double click to create a schedule. The default value is false.
  * @property {boolean} [disableClick=false] - Disable click to create a schedule. The default value is false.
  * @property {boolean} [isReadOnly=false] - {@link Calendar} is read-only mode and a user can't create and modify any schedule. The default value is false.
+ * @property {boolean} [usageStatistics=true] - Let us know the hostname. If you don't want to send the hostname, please set to false.
  */
 
 /**
@@ -493,7 +496,13 @@ var mmin = Math.min;
  * });
  */
 function Calendar(container, options) {
-    var opt = options;
+    var opt = util.extend({
+        usageStatistics: true
+    }, options);
+
+    if (opt.usageStatistics === true && util.sendHostname) {
+        util.sendHostname('calendar', GA_TRACKING_ID);
+    }
 
     if (util.isString(container)) {
         container = document.querySelector(container);


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has description for the breaking change

### Description

This allows to disable statistics (Google Analytics) via options. The previous method via `require('tui-code-snippet.js')` still works.

Tracking information are send at the calendar constructor instead of module import. 

This is the same behaviour like e.g. [tui.image-editor](https://github.com/nhnent/tui.image-editor)

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
